### PR TITLE
Fix buildenv and configure for pcre

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -1,6 +1,6 @@
-export ZOPEN_GIT_URL="https://github.com/PhilipHazel/pcre2.git"
-export ZOPEN_TARBALL_URL="https://github.com/PCRE2Project/pcre2/releases/download/pcre2-10.42/pcre2-10.42.tar.gz"
-export ZOPEN_TARBALL_DEPS="make coreutils diffutils grep zoslib"
+export ZOPEN_GIT_URL=""
+export ZOPEN_TARBALL_URL="https://sourceforge.net/projects/pcre/files/pcre/8.45/pcre-8.45.tar.gz"
+export ZOPEN_TARBALL_DEPS="make coreutils diffutils grep libtool zoslib"
 export ZOPEN_TYPE="TARBALL"
 
 zopen_check_results()
@@ -36,5 +36,5 @@ zopen_append_to_setup()
 
 zopen_get_version()
 {
-  grep "PACKAGE_VERSION" src/config.h.generic | awk -F"\"" '{print $2}'
+  grep "PACKAGE_VERSION" config.h.generic | awk -F"\"" '{print $2}'
 }

--- a/patches/configure.patch
+++ b/patches/configure.patch
@@ -1,0 +1,15 @@
+diff --git a/configure b/configure
+index 2711b18..619d6c2 100755
+--- a/configure
++++ b/configure
+@@ -8461,6 +8461,10 @@ aix[4-9]*)
+   lt_cv_deplibs_check_method=pass_all
+   ;;
+ 
++openedition)
++  lt_cv_deplibs_check_method=pass_all
++  ;;
++
+ beos*)
+   lt_cv_deplibs_check_method=pass_all
+   ;;


### PR DESCRIPTION
Libpcre should now build with zopen build and currently passes 4/5 tests.

Changes made:
- Updated tarball url in buildenv to use pcre instead of pcre2
- Updated zopen_get_version
- Added a patch for configure
